### PR TITLE
Moved apt-get update to the top

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:precise
 
+RUN apt-get update
 RUN apt-get install -y python-software-properties python build-essential git
 RUN add-apt-repository -y ppa:chris-lea/node.js
 RUN add-apt-repository -y "deb http://archive.canonical.com/ $(lsb_release -sc) partner"
 RUN echo deb http://archive.ubuntu.com/ubuntu precise main universe >> /etc/apt/sources.list
-RUN apt-get update
 RUN apt-get install -y xvfb x11-xkb-utils xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic nodejs skype python-pip redis-server
 RUN npm install -g hubot coffee-script
 RUN hubot --create hubot-skype


### PR DESCRIPTION
It can't find some packages on the first apt-get install, so I moved apt-get update on top.
